### PR TITLE
feat: add create page endpoint

### DIFF
--- a/packages/entities/notion.ts
+++ b/packages/entities/notion.ts
@@ -8,3 +8,22 @@ interface AvaiableElections {
   electionId: string;
   electionName: string;
 }
+
+export interface CreateElectionResultResponse {
+  message: string;
+  id?: string;
+}
+
+export interface CreateResultPage {
+  databaseId: string;
+  electionName: string;
+  electionId: string;
+  winnerParty: Party;
+  looserParty: Party;
+}
+
+interface Party {
+  name: string;
+  members: string[];
+  votes: string;
+}

--- a/packages/notion/client.ts
+++ b/packages/notion/client.ts
@@ -1,7 +1,11 @@
 import { Client } from '@notionhq/client';
 
+import {
+  AvaiableElectionsReturn,
+  CreateResultPage,
+} from '@packages/entities/notion';
+import { createResultPageFromTemplate } from '@packages/notion/templates';
 import { extractPagesFromQuery } from '@packages/notion/utils';
-import { AvaiableElectionsReturn } from '@packages/entities/notion';
 
 const notion = new Client({
   auth: process.env.NEXT_PUBLIC_NOTION_API_KEY,
@@ -27,3 +31,10 @@ export async function getAvaiableElections(
     message: `${electionPages.length} pages found`,
   };
 }
+
+export const postElectionResult = async (pageConfig: CreateResultPage) => {
+  const newPage = createResultPageFromTemplate(pageConfig);
+  const result = await notion.pages.create(newPage);
+
+  return result.id;
+};

--- a/packages/notion/templates.ts
+++ b/packages/notion/templates.ts
@@ -1,0 +1,146 @@
+import { CreatePageParameters } from '@notionhq/client/build/src/api-endpoints';
+
+import { CreateResultPage } from '@packages/entities/notion';
+
+export function createResultPageFromTemplate({
+  databaseId,
+  electionId,
+  electionName,
+  winnerParty,
+  looserParty,
+}: CreateResultPage) {
+  const winningMemberBlocks = winnerParty.members.map((member_name) =>
+    _createCandidateBlocks(member_name),
+  );
+  const looserMemberBlocks = looserParty.members.map((member_name) =>
+    _createCandidateBlocks(member_name),
+  );
+  return {
+    parent: {
+      type: 'database_id',
+      database_id: `${databaseId}`,
+    },
+    icon: {
+      type: 'emoji',
+      emoji: '✔️',
+    },
+    properties: {
+      Name: {
+        title: [
+          {
+            text: {
+              content: `Resultado - ${electionName}`,
+            },
+          },
+        ],
+      },
+      Eleições: {
+        type: 'relation',
+        relation: [{ id: `${electionId}` }],
+      },
+    },
+    children: [
+      {
+        object: 'block',
+        type: 'heading_1',
+        heading_1: {
+          rich_text: [
+            {
+              type: 'text',
+              text: {
+                content: `Partido Vencedor - ${winnerParty.name} - ${winnerParty.votes} Votos`,
+                link: null,
+              },
+              annotations: {
+                bold: false,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: false,
+                color: 'default',
+              },
+            },
+          ],
+          color: 'default',
+        },
+      },
+      {
+        object: 'block',
+        type: 'paragraph',
+        paragraph: {
+          rich_text: [
+            {
+              type: 'text',
+              text: {
+                content: 'Candidatos vencedores:',
+                link: null,
+              },
+            },
+          ],
+          color: 'default',
+        },
+      },
+      ...winningMemberBlocks,
+      {
+        object: 'block',
+        type: 'divider',
+        divider: {},
+      },
+      {
+        object: 'block',
+        type: 'heading_1',
+        heading_1: {
+          rich_text: [
+            {
+              type: 'text',
+              text: {
+                content: `Segundo colocado - ${looserParty.name} - ${looserParty.votes} Votos`,
+                link: null,
+              },
+              annotations: {
+                bold: false,
+                italic: false,
+                strikethrough: false,
+                underline: false,
+                code: false,
+                color: 'default',
+              },
+            },
+          ],
+          color: 'default',
+        },
+      },
+      {
+        object: 'block',
+        type: 'paragraph',
+        paragraph: {
+          rich_text: [
+            {
+              type: 'text',
+              text: {
+                content: 'Candidatos:',
+                link: null,
+              },
+            },
+          ],
+          color: 'default',
+        },
+      },
+      ...looserMemberBlocks,
+    ],
+  } as CreatePageParameters;
+}
+
+const _createCandidateBlocks = (candidate_name: string) => ({
+  type: 'bulleted_list_item',
+  bulleted_list_item: {
+    rich_text: [
+      {
+        type: 'text',
+        text: {
+          content: `${candidate_name}`,
+        },
+      },
+    ],
+  },
+});

--- a/pages/api/elections/result.ts
+++ b/pages/api/elections/result.ts
@@ -1,0 +1,26 @@
+import { postElectionResult } from '@packages/notion/client';
+import {
+  CreateResultPage,
+  CreateElectionResultResponse,
+} from '@packages/entities/notion';
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<CreateElectionResultResponse>,
+) {
+  if (req.method !== 'POST')
+    return res.status(405).json({ message: 'Only POST requests allowed' });
+
+  const pageParams = req.body;
+  // TODO(Frattezi): Add body and query parameters parser.
+  const pageConfig = {
+    ...req.query,
+    ...pageParams,
+  } as CreateResultPage;
+
+  const pageId = await postElectionResult(pageConfig);
+
+  res.status(200).json({ message: 'Page successfully created.', id: pageId });
+}


### PR DESCRIPTION
# Why is this PR necessary, what does it do?

This PR adds up to the notion client by creating a new create notion page method and endpoint.

**Sample API url**
`localhost:3000/api/elections/result?databaseId={{resultDatabaseId}}&electionId={{electionId}}`

**Sample API request body**
```json
{
	"electionName": "Teste - automatizado2",
	"winnerParty": {
		"name": "Partido teste vencedor",
		"members": ["frattezi", "joel"],
        "votes": "25"
	},
	"looserParty": {
		"name": "PMDB",
		"members": ["melga", "marquin"],
        "votes": "10"
    }
}
```

**Sample API return**
```json
{
    "message": "Page successfully created.",
    "id": "97e6a26d-f126-4cab-a42e-869647c7f466"
}
```

## Observations
I've noticed that the API is kinda dummy. I believe notion cannot be used as a traditional database, if we want in the future, to execute calculations and be more trustworthy to the real process, we should add maybe a mongodb  and use notion only as a final result summary for example.

Updated the [Postman Collection](https://www.getpostman.com/collections/4ef9e3a7693171cc3b16)
Relates to #2 