### PR TITLE
feat: add configuration menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@chakra-ui/icons": "^2.0.2",
     "@chakra-ui/react": "^2.2.1",
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",

--- a/packages/components/ConfigModal/ConfigForm.tsx
+++ b/packages/components/ConfigModal/ConfigForm.tsx
@@ -15,7 +15,7 @@ export default function ConfigForm({ onChange, formState }: IConfigForm) {
         />
       </FormControl>
 
-      <FormControl mt={4}>
+      <FormControl mt="4">
         <FormLabel fontWeight="bold">Eleições Database Id</FormLabel>
         <Input
           name="electionDatabaseId"
@@ -25,7 +25,7 @@ export default function ConfigForm({ onChange, formState }: IConfigForm) {
         />
       </FormControl>
 
-      <FormControl mt={4}>
+      <FormControl mt="4">
         <FormLabel fontWeight="bold">Resultados Database Id</FormLabel>
         <Input
           name="resultsDatabaseId"

--- a/packages/components/ConfigModal/ConfigForm.tsx
+++ b/packages/components/ConfigModal/ConfigForm.tsx
@@ -1,8 +1,20 @@
+import { ChangeEvent } from 'react';
 import { FormLabel, Input } from '@chakra-ui/react';
 
 import { IConfigForm } from '@packages/entities/config-modal';
 
-export default function ConfigForm({ onChange, formState }: IConfigForm) {
+export default function ConfigForm({
+  setFormState,
+  formState,
+  initialRef,
+}: IConfigForm) {
+  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setFormState({
+      ...formState,
+      [event.target.name]: event.target.value,
+    });
+  };
+
   return (
     <>
       <FormLabel fontWeight="bold">Notion API Key</FormLabel>
@@ -11,6 +23,7 @@ export default function ConfigForm({ onChange, formState }: IConfigForm) {
         placeholder="Sua chave de integração Notion"
         value={formState.notionApiKey}
         onChange={onChange}
+        ref={initialRef}
       />
 
       <FormLabel fontWeight="bold" mt="4">

--- a/packages/components/ConfigModal/ConfigForm.tsx
+++ b/packages/components/ConfigModal/ConfigForm.tsx
@@ -1,39 +1,37 @@
-import { FormControl, FormLabel, Input } from '@chakra-ui/react';
+import { FormLabel, Input } from '@chakra-ui/react';
 
 import { IConfigForm } from '@packages/entities/config-modal';
 
 export default function ConfigForm({ onChange, formState }: IConfigForm) {
   return (
     <>
-      <FormControl>
-        <FormLabel fontWeight="bold">Notion API Key</FormLabel>
-        <Input
-          name="notionApiKey"
-          placeholder="Sua chave de integração Notion"
-          value={formState.notionApiKey}
-          onChange={onChange}
-        />
-      </FormControl>
+      <FormLabel fontWeight="bold">Notion API Key</FormLabel>
+      <Input
+        name="notionApiKey"
+        placeholder="Sua chave de integração Notion"
+        value={formState.notionApiKey}
+        onChange={onChange}
+      />
 
-      <FormControl mt="4">
-        <FormLabel fontWeight="bold">Eleições Database Id</FormLabel>
-        <Input
-          name="electionDatabaseId"
-          placeholder="Digite o Id do database de eleições"
-          value={formState.electionDatabaseId}
-          onChange={onChange}
-        />
-      </FormControl>
+      <FormLabel fontWeight="bold" mt="4">
+        Eleições Database Id
+      </FormLabel>
+      <Input
+        name="electionDatabaseId"
+        placeholder="Digite o Id do database de eleições"
+        value={formState.electionDatabaseId}
+        onChange={onChange}
+      />
 
-      <FormControl mt="4">
-        <FormLabel fontWeight="bold">Resultados Database Id</FormLabel>
-        <Input
-          name="resultsDatabaseId"
-          placeholder="Digite o Id do database de resultados"
-          value={formState.resultsDatabaseId}
-          onChange={onChange}
-        />
-      </FormControl>
+      <FormLabel fontWeight="bold" mt="4">
+        Resultados Database Id
+      </FormLabel>
+      <Input
+        name="resultsDatabaseId"
+        placeholder="Digite o Id do database de resultados"
+        value={formState.resultsDatabaseId}
+        onChange={onChange}
+      />
     </>
   );
 }

--- a/packages/components/ConfigModal/ConfigForm.tsx
+++ b/packages/components/ConfigModal/ConfigForm.tsx
@@ -1,0 +1,39 @@
+import { FormControl, FormLabel, Input } from '@chakra-ui/react';
+
+import { IConfigForm } from '@packages/entities/config-modal';
+
+export default function ConfigForm({ onChange, formState }: IConfigForm) {
+  return (
+    <>
+      <FormControl>
+        <FormLabel fontWeight="bold">Notion API Key</FormLabel>
+        <Input
+          name="notionApiKey"
+          placeholder="Sua chave de integração Notion"
+          value={formState.notionApiKey}
+          onChange={onChange}
+        />
+      </FormControl>
+
+      <FormControl mt={4}>
+        <FormLabel fontWeight="bold">Eleições Database Id</FormLabel>
+        <Input
+          name="electionDatabaseId"
+          placeholder="Digite o Id do database de eleições"
+          value={formState.electionDatabaseId}
+          onChange={onChange}
+        />
+      </FormControl>
+
+      <FormControl mt={4}>
+        <FormLabel fontWeight="bold">Resultados Database Id</FormLabel>
+        <Input
+          name="resultsDatabaseId"
+          placeholder="Digite o Id do database de resultados"
+          value={formState.resultsDatabaseId}
+          onChange={onChange}
+        />
+      </FormControl>
+    </>
+  );
+}

--- a/packages/components/ConfigModal/ConfigForm.tsx
+++ b/packages/components/ConfigModal/ConfigForm.tsx
@@ -17,15 +17,6 @@ export default function ConfigForm({
 
   return (
     <>
-      <FormLabel fontWeight="bold">Notion API Key</FormLabel>
-      <Input
-        name="notionApiKey"
-        placeholder="Sua chave de integração Notion"
-        value={formState.notionApiKey}
-        onChange={onChange}
-        ref={initialRef}
-      />
-
       <FormLabel fontWeight="bold" mt="4">
         Eleições Database Id
       </FormLabel>
@@ -34,6 +25,7 @@ export default function ConfigForm({
         placeholder="Digite o Id do database de eleições"
         value={formState.electionDatabaseId}
         onChange={onChange}
+        ref={initialRef}
       />
 
       <FormLabel fontWeight="bold" mt="4">

--- a/packages/components/ConfigModal/index.tsx
+++ b/packages/components/ConfigModal/index.tsx
@@ -46,7 +46,7 @@ export default function ConfigModal({ isOpen, onClose }: IConfigModal) {
         <ModalBody>
           <ConfigForm onChange={onChangeInput} formState={formState} />
 
-          <Box bgColor={boxBgColor} padding="10px" marginTop="10px">
+          <Box bgColor={boxBgColor} padding="10px" mt="8">
             <Text fontSize="0.8em">
               {' '}
               Caso ainda não tenha estes dados lembre-se de seguir nosso{' '}
@@ -61,7 +61,7 @@ export default function ConfigModal({ isOpen, onClose }: IConfigModal) {
         </ModalBody>
 
         <ModalFooter>
-          <Button colorScheme="red" mr={3} onClick={onClose}>
+          <Button colorScheme="red" mr="3" onClick={onClose}>
             Close
           </Button>
           <Button variant="solid" colorScheme="blue" onClick={onSubmmit}>

--- a/packages/components/ConfigModal/index.tsx
+++ b/packages/components/ConfigModal/index.tsx
@@ -62,7 +62,7 @@ export default function ConfigModal({ isOpen, onClose }: IConfigModal) {
 
         <ModalFooter>
           <Button colorScheme="red" mr="3" onClick={onClose}>
-            Close
+            Fechar
           </Button>
           <Button variant="solid" colorScheme="blue" onClick={onSubmmit}>
             Atualizar dados

--- a/packages/components/ConfigModal/index.tsx
+++ b/packages/components/ConfigModal/index.tsx
@@ -7,6 +7,10 @@ import {
   ModalBody,
   ModalFooter,
   Button,
+  Box,
+  Text,
+  Link,
+  useColorModeValue,
 } from '@chakra-ui/react';
 import { ChangeEvent, useState } from 'react';
 
@@ -14,6 +18,7 @@ import ConfigForm from '@packages/components/ConfigModal/ConfigForm';
 import { IConfigModal, FormState } from '@packages/entities/config-modal';
 
 export default function ConfigModal({ isOpen, onClose }: IConfigModal) {
+  const boxBgColor = useColorModeValue('gray.100', 'gray.900');
   const [formState, setFormState] = useState<FormState>({
     notionApiKey: '',
     electionDatabaseId: '',
@@ -40,6 +45,19 @@ export default function ConfigModal({ isOpen, onClose }: IConfigModal) {
 
         <ModalBody>
           <ConfigForm onChange={onChangeInput} formState={formState} />
+
+          <Box bgColor={boxBgColor} padding="10px" marginTop="10px">
+            <Text fontSize="0.8em">
+              {' '}
+              Caso ainda não tenha estes dados lembre-se de seguir nosso{' '}
+              <Link
+                color="teal.500"
+                href="https://www.notion.so/podcodar/Docs-7e84b843b0ee496d8f4bf3e59683072a"
+              >
+                tutorial de setup do projeto
+              </Link>
+            </Text>
+          </Box>
         </ModalBody>
 
         <ModalFooter>

--- a/packages/components/ConfigModal/index.tsx
+++ b/packages/components/ConfigModal/index.tsx
@@ -1,0 +1,56 @@
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalCloseButton,
+  ModalBody,
+  ModalFooter,
+  Button,
+} from '@chakra-ui/react';
+import { ChangeEvent, useState } from 'react';
+
+import ConfigForm from '@packages/components/ConfigModal/ConfigForm';
+import { IConfigModal, FormState } from '@packages/entities/config-modal';
+
+export default function ConfigModal({ isOpen, onClose }: IConfigModal) {
+  const [formState, setFormState] = useState<FormState>({
+    notionApiKey: '',
+    electionDatabaseId: '',
+    resultsDatabaseId: '',
+  });
+
+  const onChangeInput = (event: ChangeEvent<HTMLInputElement>) => {
+    setFormState({
+      ...formState,
+      [event.target.name]: event.target.value,
+    });
+  };
+
+  const onSubmmit = () => {
+    console.log(formState);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Adicione suas chaves do notion</ModalHeader>
+        <ModalCloseButton />
+
+        <ModalBody>
+          <ConfigForm onChange={onChangeInput} formState={formState} />
+        </ModalBody>
+
+        <ModalFooter>
+          <Button colorScheme="red" mr={3} onClick={onClose}>
+            Close
+          </Button>
+          <Button variant="solid" colorScheme="blue" onClick={onSubmmit}>
+            Atualizar dados
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/packages/components/ConfigModal/index.tsx
+++ b/packages/components/ConfigModal/index.tsx
@@ -12,12 +12,13 @@ import {
   Link,
   useColorModeValue,
 } from '@chakra-ui/react';
-import { ChangeEvent, useState } from 'react';
+import { useRef, useState } from 'react';
 
 import ConfigForm from '@packages/components/ConfigModal/ConfigForm';
 import { IConfigModal, FormState } from '@packages/entities/config-modal';
 
 export default function ConfigModal({ isOpen, onClose }: IConfigModal) {
+  const initialRef = useRef(null);
   const boxBgColor = useColorModeValue('gray.100', 'gray.900');
   const [formState, setFormState] = useState<FormState>({
     notionApiKey: '',
@@ -25,26 +26,23 @@ export default function ConfigModal({ isOpen, onClose }: IConfigModal) {
     resultsDatabaseId: '',
   });
 
-  const onChangeInput = (event: ChangeEvent<HTMLInputElement>) => {
-    setFormState({
-      ...formState,
-      [event.target.name]: event.target.value,
-    });
-  };
-
   const onSubmmit = () => {
     console.log(formState);
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal isOpen={isOpen} onClose={onClose} initialFocusRef={initialRef}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>Adicione suas chaves do notion</ModalHeader>
         <ModalCloseButton />
 
         <ModalBody>
-          <ConfigForm onChange={onChangeInput} formState={formState} />
+          <ConfigForm
+            setFormState={setFormState}
+            formState={formState}
+            initialRef={initialRef}
+          />
 
           <Box bgColor={boxBgColor} padding="10px" mt="8">
             <Text fontSize="0.8em">

--- a/packages/components/NavBar.tsx
+++ b/packages/components/NavBar.tsx
@@ -1,0 +1,43 @@
+import {
+  Box,
+  Button,
+  Container,
+  Heading,
+  useColorModeValue,
+  useDisclosure,
+} from '@chakra-ui/react';
+import { EditIcon } from '@chakra-ui/icons';
+
+import ConfigModal from '@packages/components/ConfigModal';
+
+export default function NavBar() {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const navbarBgColor = useColorModeValue('gray.50', 'gray.900');
+
+  return (
+    <Box
+      position="sticky"
+      w="100%"
+      top={0}
+      shadow="base"
+      zIndex={1}
+      bg={navbarBgColor}
+    >
+      <Container
+        p="1rem"
+        display="flex"
+        maxW="5xl"
+        justifyContent="space-between"
+      >
+        <Button onClick={onOpen}>
+          Configurações Notion <EditIcon paddingLeft="2px" />
+        </Button>
+
+        <Heading color="teal.500" as="h3">
+          Voting-System
+        </Heading>
+        <ConfigModal isOpen={isOpen} onClose={onClose} />
+      </Container>
+    </Box>
+  );
+}

--- a/packages/components/NavBar.tsx
+++ b/packages/components/NavBar.tsx
@@ -29,7 +29,7 @@ export default function NavBar() {
         maxW="5xl"
         justifyContent="space-between"
       >
-        <Button onClick={onOpen}>
+        <Button onClick={onOpen} colorScheme="blue">
           Configurações Notion <EditIcon paddingLeft="2px" />
         </Button>
 

--- a/packages/entities/config-modal.ts
+++ b/packages/entities/config-modal.ts
@@ -1,4 +1,4 @@
-import { ChangeEvent } from 'react';
+import { Dispatch, LegacyRef, SetStateAction } from 'react';
 
 export interface IConfigModal {
   isOpen: boolean;
@@ -6,8 +6,9 @@ export interface IConfigModal {
 }
 
 export interface IConfigForm {
-  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  setFormState: Dispatch<SetStateAction<FormState>>;
   formState: FormState;
+  initialRef: LegacyRef<HTMLInputElement>;
 }
 
 export interface FormState {

--- a/packages/entities/config-modal.ts
+++ b/packages/entities/config-modal.ts
@@ -1,0 +1,17 @@
+import { ChangeEvent } from 'react';
+
+export interface IConfigModal {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export interface IConfigForm {
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  formState: FormState;
+}
+
+export interface FormState {
+  notionApiKey: string;
+  electionDatabaseId: string;
+  resultsDatabaseId: string;
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,8 @@
 import { Heading, Box, Flex, Select, Button } from '@chakra-ui/react';
 import Head from 'next/head';
 
+import NavBar from '@packages/components/NavBar';
+
 import type { NextPage } from 'next';
 
 const mockElections = [

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,7 +3,7 @@ import Head from 'next/head';
 
 import type { NextPage } from 'next';
 
-const listElection = [
+const mockElections = [
   {
     electionId: '47b8e344-0243-435d-822b-4192f691f5a7',
     electionName: 'Dimensão colégio - 06',
@@ -36,7 +36,7 @@ const Home: NextPage = () => {
             py="30px"
           >
             <Select>
-              {listElection.map((voting) => (
+              {mockElections.map((voting) => (
                 <option key={voting.electionName}>{voting.electionName}</option>
               ))}
             </Select>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -20,35 +20,40 @@ const mockElections = [
 
 const Home: NextPage = () => {
   return (
-    <Flex h="100vh" w="100vw" alignItems="center" justifyContent="center">
-      <Box>
-        <Head>
-          <title>Eleições 2022</title>
-          <link rel="icon" href="/favicon.ico" />
-        </Head>
-        <main>
-          <Heading as="h1" size="2xl">
-            Selecione uma votação{' '}
-          </Heading>
-          <Box
-            display="flex"
-            alignItems="center"
-            justifyContent="center"
-            width="100%"
-            py="30px"
-          >
-            <Select>
-              {mockElections.map((voting) => (
-                <option key={voting.electionName}>{voting.electionName}</option>
-              ))}
-            </Select>
-            <Button colorScheme="blue" marginLeft="10px">
-              Iniciar Votação
-            </Button>
-          </Box>
-        </main>
-      </Box>
-    </Flex>
+    <>
+      <NavBar />
+      <Flex h="80vh" w="100vw" alignItems="center" justifyContent="center">
+        <Box>
+          <Head>
+            <title>Eleições 2022</title>
+            <link rel="icon" href="/favicon.ico" />
+          </Head>
+          <main>
+            <Heading as="h1" size="2xl">
+              Selecione uma votação{' '}
+            </Heading>
+            <Box
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              width="100%"
+              py="30px"
+            >
+              <Select>
+                {mockElections.map((voting) => (
+                  <option key={voting.electionName}>
+                    {voting.electionName}
+                  </option>
+                ))}
+              </Select>
+              <Button colorScheme="blue" marginLeft="10px">
+                Iniciar Votação
+              </Button>
+            </Box>
+          </main>
+        </Box>
+      </Flex>
+    </>
   );
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -228,6 +228,14 @@
   dependencies:
     "@chakra-ui/utils" "2.0.2"
 
+"@chakra-ui/icons@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/icons/-/icons-2.0.2.tgz#4ef4c3e1c6eb7a8f7d5de59635811f0c68104d4b"
+  integrity sha512-UY7vP8E5pv2a4sd1SiezgVbmq1/tRfnehk6PatunrTvGMxQNhSKJJoiRI/wCtUfMoMz+yp9+ekc1ksJVCnokRg==
+  dependencies:
+    "@chakra-ui/icon" "3.0.2"
+    "@types/react" "^18.0.1"
+
 "@chakra-ui/image@2.0.3":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@chakra-ui/image/-/image-2.0.3.tgz#49a73c39aacbec1c956503adf1b20cd945889593"
@@ -945,6 +953,15 @@
   version "18.0.11"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.11.tgz#94c9b62020caff17d117374d724de853ec711d21"
   integrity sha512-JxSwm54IgMW4XTR+zFF5QpNx4JITmFbB4WHR2J0vg9RpjNeyqEMlODXsD2e64br6GX70TL0UYjZJETpyyC1WdA==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^18.0.1":
+  version "18.0.14"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.14.tgz#e016616ffff51dba01b04945610fe3671fdbe06d"
+  integrity sha512-x4gGuASSiWmo0xjDLpm5mPb52syZHJx02VKbqUKdLmKtAwIh63XClGsiTI1K6DO5q7ox4xAsQrU+Gl3+gGXF9Q==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
# Description

This PR add's a new button at the navbar that opens a Modal with a form. This form consists of some variables from Notion that our app will need to run the election.

## Changes

- Minor upgrade in the index page looks
- Created NavBar and added to index page
- Created new Modal with a form so the app can get the notion configuration data.

![Screenshot from 2022-06-27 23-33-20](https://user-images.githubusercontent.com/14007745/176079579-63e97fed-faf3-48e7-857c-a93a48cc01f0.png)
![Screenshot from 2022-06-27 23-33-06](https://user-images.githubusercontent.com/14007745/176079589-bd69aa64-64d6-4e4e-8cb9-cc41cbd2cbf8.png)

## Notes

- Just focused on design and creating the components, I will create a new context and bind the configuration form to it. This is listed in #32 
- The index page was not an objective, @Joel-leal is already changing it at #21 

## Board issue

- Closes #30 
