### PR TITLE
feat: add context for config form

### DIFF
--- a/packages/components/ConfigModal/ConfigForm.tsx
+++ b/packages/components/ConfigModal/ConfigForm.tsx
@@ -1,19 +1,14 @@
-import { ChangeEvent } from 'react';
 import { FormLabel, Input } from '@chakra-ui/react';
 
+import {
+  useConfigActions,
+  useConfigStates,
+} from '@packages/features/config-context';
 import { IConfigForm } from '@packages/entities/config-modal';
 
-export default function ConfigForm({
-  setFormState,
-  formState,
-  initialRef,
-}: IConfigForm) {
-  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setFormState({
-      ...formState,
-      [event.target.name]: event.target.value,
-    });
-  };
+export default function ConfigForm({ initialRef }: IConfigForm) {
+  const { onConfigChange } = useConfigActions();
+  const { electionDatabaseId, resultsDatabaseId } = useConfigStates();
 
   return (
     <>
@@ -23,9 +18,9 @@ export default function ConfigForm({
       <Input
         name="electionDatabaseId"
         placeholder="Digite o Id do database de eleições"
-        value={formState.electionDatabaseId}
-        onChange={onChange}
         ref={initialRef}
+        value={electionDatabaseId}
+        onChange={onConfigChange}
       />
 
       <FormLabel fontWeight="bold" mt="4">
@@ -34,8 +29,8 @@ export default function ConfigForm({
       <Input
         name="resultsDatabaseId"
         placeholder="Digite o Id do database de resultados"
-        value={formState.resultsDatabaseId}
-        onChange={onChange}
+        value={resultsDatabaseId}
+        onChange={onConfigChange}
       />
     </>
   );

--- a/packages/components/ConfigModal/index.tsx
+++ b/packages/components/ConfigModal/index.tsx
@@ -12,21 +12,19 @@ import {
   Link,
   useColorModeValue,
 } from '@chakra-ui/react';
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 
 import ConfigForm from '@packages/components/ConfigModal/ConfigForm';
-import { IConfigModal, FormState } from '@packages/entities/config-modal';
+import { IConfigModal } from '@packages/entities/config-modal';
+import { useConfigStates } from '@packages/features/config-context';
 
 export default function ConfigModal({ isOpen, onClose }: IConfigModal) {
   const initialRef = useRef(null);
+  const formState = useConfigStates();
   const boxBgColor = useColorModeValue('gray.100', 'gray.900');
-  const [formState, setFormState] = useState<FormState>({
-    notionApiKey: '',
-    electionDatabaseId: '',
-    resultsDatabaseId: '',
-  });
 
   const onSubmmit = () => {
+    // TODO(Frattezi): onSubmit should be the localStorage persistence moment
     console.log(formState);
   };
 
@@ -38,11 +36,7 @@ export default function ConfigModal({ isOpen, onClose }: IConfigModal) {
         <ModalCloseButton />
 
         <ModalBody>
-          <ConfigForm
-            setFormState={setFormState}
-            formState={formState}
-            initialRef={initialRef}
-          />
+          <ConfigForm initialRef={initialRef} />
 
           <Box bgColor={boxBgColor} padding="10px" mt="8">
             <Text fontSize="0.8em">

--- a/packages/entities/config-modal.ts
+++ b/packages/entities/config-modal.ts
@@ -1,4 +1,4 @@
-import { Dispatch, LegacyRef, SetStateAction } from 'react';
+import { LegacyRef } from 'react';
 
 export interface IConfigModal {
   isOpen: boolean;
@@ -6,13 +6,10 @@ export interface IConfigModal {
 }
 
 export interface IConfigForm {
-  setFormState: Dispatch<SetStateAction<FormState>>;
-  formState: FormState;
   initialRef: LegacyRef<HTMLInputElement>;
 }
 
 export interface FormState {
-  notionApiKey: string;
   electionDatabaseId: string;
   resultsDatabaseId: string;
 }

--- a/packages/features/config-context.tsx
+++ b/packages/features/config-context.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+
+import { ChildrenProps, ReactEvent } from '@packages/utils/react';
+import createCtx from '@packages/utils/createCtx';
+import { FormState } from '@packages/entities/config-modal';
+
+interface ConfigActions {
+  readonly onConfigChange: (event: ReactEvent) => void;
+}
+
+interface ConfigStates {
+  readonly notionApiKey: string;
+  readonly electionDatabaseId: string;
+  readonly resultsDatabaseId: string;
+}
+
+const [useConfigActions, ConfigActionsProvider] =
+  createCtx<ConfigActions>('ConfigActionsCtx');
+const [useConfigStates, ConfigStatesProvider] =
+  createCtx<ConfigStates>('ConfigStatesCtx');
+
+function ConfigProvider({ children }: ChildrenProps) {
+  const [formState, setFormState] = useState<FormState>({
+    notionApiKey: '',
+    electionDatabaseId: '',
+    resultsDatabaseId: '',
+  });
+
+  const onConfigChange = (event: ReactEvent) => {
+    setFormState({
+      ...formState,
+      [event.target.name]: event.target.value,
+    });
+  };
+
+  const actions: ConfigActions = {
+    onConfigChange: (event) => onConfigChange(event),
+  };
+
+  return (
+    <ConfigActionsProvider value={actions}>
+      <ConfigStatesProvider value={formState}>{children}</ConfigStatesProvider>
+    </ConfigActionsProvider>
+  );
+}
+
+export default ConfigProvider;
+export { useConfigActions, useConfigStates };

--- a/packages/features/config-context.tsx
+++ b/packages/features/config-context.tsx
@@ -35,7 +35,7 @@ function ConfigProvider({ children }: ChildrenProps) {
   );
 
   const actions: ConfigActions = {
-    onConfigChange: (event) => onConfigChange(event),
+    onConfigChange,
   };
 
   return (

--- a/packages/features/config-context.tsx
+++ b/packages/features/config-context.tsx
@@ -9,7 +9,6 @@ interface ConfigActions {
 }
 
 interface ConfigStates {
-  readonly notionApiKey: string;
   readonly electionDatabaseId: string;
   readonly resultsDatabaseId: string;
 }
@@ -21,7 +20,6 @@ const [useConfigStates, ConfigStatesProvider] =
 
 function ConfigProvider({ children }: ChildrenProps) {
   const [formState, setFormState] = useState<FormState>({
-    notionApiKey: '',
     electionDatabaseId: '',
     resultsDatabaseId: '',
   });

--- a/packages/features/config-context.tsx
+++ b/packages/features/config-context.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { ChildrenProps, ReactEvent } from '@packages/utils/react';
 import createCtx from '@packages/utils/createCtx';
@@ -24,12 +24,15 @@ function ConfigProvider({ children }: ChildrenProps) {
     resultsDatabaseId: '',
   });
 
-  const onConfigChange = (event: ReactEvent) => {
-    setFormState({
-      ...formState,
-      [event.target.name]: event.target.value,
-    });
-  };
+  const onConfigChange = useCallback(
+    (event: ReactEvent) => {
+      setFormState((formState) => ({
+        ...formState,
+        [event.target.name]: event.target.value,
+      }));
+    },
+    [setFormState],
+  );
 
   const actions: ConfigActions = {
     onConfigChange: (event) => onConfigChange(event),

--- a/packages/utils/createCtx.ts
+++ b/packages/utils/createCtx.ts
@@ -1,0 +1,36 @@
+import { Context, createContext, useContext, Provider } from 'react';
+
+export type SafeContextResult<T> = [
+  () => T,
+  Provider<T | null>,
+  Context<T | null>,
+];
+
+/**
+ * A helper that creates a Context Consumer and Provider without having to declare a
+ * default value and checking nullable.
+ *
+ * @example
+ * export const [useAuth, AuthProvider] = createSafeContext<AuthView>('AuthCtx')
+ *
+ * @param displayName Context name displayed in React Component's Tree
+ * @returns A context consumer, the context provider and the context itself
+ */
+function createCtx<T>(displayName: Readonly<string>): SafeContextResult<T> {
+  const Ctx = createContext<T | null>(null);
+  Ctx.displayName = displayName;
+
+  function useCtx() {
+    const value = useContext(Ctx);
+    if (value === null)
+      throw new Error(
+        `Missing ${displayName} context provider upwards on this tree`,
+      );
+
+    return value;
+  }
+
+  return [useCtx, Ctx.Provider, Ctx];
+}
+
+export default createCtx;

--- a/packages/utils/react.tsx
+++ b/packages/utils/react.tsx
@@ -1,0 +1,22 @@
+import { EffectCallback, FC, ReactNode, useEffect, ChangeEvent } from 'react';
+
+export type ReactEvent = ChangeEvent<HTMLInputElement>;
+
+export interface ChildrenProps {
+  readonly children: ReactNode;
+}
+
+export function useEffectOnce(effect: EffectCallback) {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(effect, []);
+}
+
+export function withProviders(
+  initialElement: ReactNode,
+  providers: FC<ChildrenProps>[],
+) {
+  return providers.reduce(
+    (children, Provider) => <Provider>{children}</Provider>,
+    initialElement,
+  );
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,15 +2,21 @@ import '../styles/globals.css';
 
 import { ChakraProvider, theme, CSSReset } from '@chakra-ui/react';
 
+import { withProviders } from '@packages/utils/react';
+import ConfigProvider from '@packages/features/config-context';
+
 import type { AppProps } from 'next/app';
 
 function MyApp({ Component, pageProps }: AppProps) {
-  return (
+  return withProviders(
     <ChakraProvider theme={theme}>
       <CSSReset />
       <Component {...pageProps} />
-    </ChakraProvider>
+    </ChakraProvider>,
+    providers,
   );
 }
+
+const providers = [ConfigProvider];
 
 export default MyApp;


### PR DESCRIPTION
# Description

We need to start dealing with data in our platform. For that, I've added a new config-context and some context helpers, following patterns that already exist at our brother project `prodcodar/webapp`.

I'm opening this as a draft because It's late and I want that we could think about how we should handle context and data in our app. After creating this context, I think we should separate contexts into something like:

- config-context // A context to handle notion keys and database id's
- election-context // A context to handle the election cycle, numbers input, and candidate votes...

With those, we can already create the requests we need to communicate with our backend. But well I also want to hear your ideas, please help me!

## Changes

- Add utility modules for context creation
- Create a new config context, that holds and manipulates notion-related data.

## Notes

- @borgesgfj @fmagesty I'm opening this PR kinda "in a hurry" to also help you guys with your tasks. I believe that you could create a context just like this to share data and methods for both your components ^^
- Will bind the system to local storage or another persistence method in another task.
- Relates to #33 

## Board issue

- Closes #32 
