### PR TITLE
fix: add position to response payload

### DIFF
--- a/packages/notion/utils.ts
+++ b/packages/notion/utils.ts
@@ -47,6 +47,7 @@ export function extractPagesFromQuery(pages: Result[]) {
     const pageProperties = _extractProperties(page);
     return {
       electionId: page?.id,
+      position: pageProperties?.Cargo,
       electionName: pageProperties?.Name,
       partySlug: pageProperties?.Sigla,
       candidateName: pageProperties?.Candidato,


### PR DESCRIPTION
# Description

Add's the position which the candidates are running for in the response payload for the `getElection` API call. Maybe not a bug because there are no clients but it should already be there.

## Changes

- Add the parse of "Cargo" in the page data extractor

## Board issue

- N/A