### PR TITLE
feat: index db persistence to project

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
     "@notionhq/client": "^1.0.4",
+    "dexie": "^3.2.2",
     "framer-motion": "^6.3.10",
     "next": "12.1.6",
     "react": "18.1.0",

--- a/packages/components/ConfigModal/index.tsx
+++ b/packages/components/ConfigModal/index.tsx
@@ -11,6 +11,7 @@ import {
   Text,
   Link,
   useColorModeValue,
+  useToast,
 } from '@chakra-ui/react';
 import { useRef } from 'react';
 
@@ -22,10 +23,12 @@ import {
 } from '@packages/features/config-context';
 import {
   getConfiguration,
-  persistConfiguration,
+  putConfiguration,
 } from '@packages/repository/indexedDb';
+import { updateConfigurationSuccess } from '@packages/utils/toast-configs';
 
 export default function ConfigModal({ isOpen, onClose }: IConfigModal) {
+  const toast = useToast();
   const initialRef = useRef(null);
   const formState = useConfigStates();
   const { updateConfiguration } = useConfigActions();
@@ -39,7 +42,8 @@ export default function ConfigModal({ isOpen, onClose }: IConfigModal) {
   };
 
   const onSubmmit = async () => {
-    await persistConfiguration(formState);
+    await putConfiguration(formState);
+    toast(updateConfigurationSuccess);
     onClose();
   };
 

--- a/packages/components/ConfigModal/index.tsx
+++ b/packages/components/ConfigModal/index.tsx
@@ -16,20 +16,40 @@ import { useRef } from 'react';
 
 import ConfigForm from '@packages/components/ConfigModal/ConfigForm';
 import { IConfigModal } from '@packages/entities/config-modal';
-import { useConfigStates } from '@packages/features/config-context';
+import {
+  useConfigActions,
+  useConfigStates,
+} from '@packages/features/config-context';
+import {
+  getConfiguration,
+  persistConfiguration,
+} from '@packages/repository/indexedDb';
 
 export default function ConfigModal({ isOpen, onClose }: IConfigModal) {
   const initialRef = useRef(null);
   const formState = useConfigStates();
+  const { updateConfiguration } = useConfigActions();
   const boxBgColor = useColorModeValue('gray.100', 'gray.900');
 
-  const onSubmmit = () => {
-    // TODO(Frattezi): onSubmit should be the localStorage persistence moment
-    console.log(formState);
+  const updateContext = async () => {
+    const persistedConfig = await getConfiguration();
+    if (persistedConfig != formState) {
+      updateConfiguration(persistedConfig);
+    }
+  };
+
+  const onSubmmit = async () => {
+    await persistConfiguration(formState);
+    onClose();
+  };
+
+  const onCloseModal = async () => {
+    await updateContext();
+    onClose();
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} initialFocusRef={initialRef}>
+    <Modal isOpen={isOpen} onClose={onCloseModal} initialFocusRef={initialRef}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>Adicione suas chaves do notion</ModalHeader>
@@ -53,7 +73,7 @@ export default function ConfigModal({ isOpen, onClose }: IConfigModal) {
         </ModalBody>
 
         <ModalFooter>
-          <Button colorScheme="red" mr="3" onClick={onClose}>
+          <Button colorScheme="red" mr="3" onClick={onCloseModal}>
             Fechar
           </Button>
           <Button variant="solid" colorScheme="blue" onClick={onSubmmit}>

--- a/packages/entities/indexedDb.ts
+++ b/packages/entities/indexedDb.ts
@@ -1,0 +1,10 @@
+export interface IConfig {
+  name: string;
+  value: string;
+}
+
+export interface IVotes {
+  id: number;
+  code: number;
+  electionId: string;
+}

--- a/packages/repository/indexedDb.ts
+++ b/packages/repository/indexedDb.ts
@@ -1,0 +1,56 @@
+import Dexie, { Table } from 'dexie';
+
+import { ConfigStates } from '@packages/features/config-context';
+
+export default class VSDatabase extends Dexie {
+  configuration!: Table<IConfig, string>;
+  votes!: Table<IVotes, number>;
+
+  constructor() {
+    super('VSDatabase');
+
+    this.version(1).stores({
+      configuration: '&name, value',
+      votes: '&id, code ',
+    });
+  }
+}
+
+export interface IConfig {
+  name: string;
+  value: string;
+}
+
+interface IVotes {
+  id: number;
+  code: number;
+  electionId: string;
+}
+
+const db = new VSDatabase();
+
+export async function getConfiguration(): Promise<ConfigStates> {
+  const [electionDatabaseId, resultsDatabaseId] =
+    await db.configuration.bulkGet(['electionDatabaseId', 'resultsDatabaseId']);
+
+  const result = {
+    electionDatabaseId: electionDatabaseId?.value || '',
+    resultsDatabaseId: resultsDatabaseId?.value || '',
+  };
+
+  return result;
+}
+
+export async function persistConfiguration(
+  configuration: ConfigStates,
+): Promise<void> {
+  const updateData = Object.entries(configuration).map(
+    ([key, value]) =>
+      ({
+        name: key,
+        value: value,
+      } as IConfig),
+  );
+
+  await db.configuration.bulkPut(updateData);
+}

--- a/packages/utils/toast-configs.tsx
+++ b/packages/utils/toast-configs.tsx
@@ -1,0 +1,8 @@
+import { UseToastOptions } from '@chakra-ui/react';
+
+export const updateConfigurationSuccess = {
+  title: 'Configurações atualizadas com sucesso!',
+  status: 'success',
+  duration: 3000,
+  isClosable: true,
+} as UseToastOptions;

--- a/packages/utils/transformers.ts
+++ b/packages/utils/transformers.ts
@@ -1,0 +1,25 @@
+import { IConfig } from '@packages/entities/indexedDb';
+import { ConfigStates } from '@packages/features/config-context';
+
+export function configPersistenceToContext(
+  configuration: ConfigStates,
+): IConfig[] {
+  return Object.entries(configuration).map(
+    ([key, value]) =>
+      ({
+        name: key,
+        value: value,
+      } as IConfig),
+  );
+}
+
+export function configContextToPersistence(
+  config: (IConfig | undefined)[],
+): ConfigStates {
+  const [electionDatabaseId, resultsDatabaseId] = config;
+
+  return {
+    electionDatabaseId: electionDatabaseId?.value || '',
+    resultsDatabaseId: resultsDatabaseId?.value || '',
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1445,6 +1445,11 @@ detect-node-es@^1.1.0:
   resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
   integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
 
+dexie@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/dexie/-/dexie-3.2.2.tgz#fa6f2a3c0d6ed0766f8d97a03720056f88fe0e01"
+  integrity sha512-q5dC3HPmir2DERlX+toCBbHQXW5MsyrFqPFcovkH9N2S/UW/H3H5AWAB6iEOExeraAu+j+zRDG+zg/D7YhH0qg==
+
 dir-glob@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"


### PR DESCRIPTION
# Description

This PR adds persistence to our project using [indexedDb](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API).

It creates a new repository with basic functions, it defines already both tables we will need `configuration` and `votes`.
I used it as leverage to keep a smart persistence for our configuration data, by updating the persisted data when needed and recovering it on application startup or if the user decides to abort a change.

## Changes

- Added new integration with indexed DB.
- Added success toast.
- Integrated persisted data with context.

![demo-persistence](https://user-images.githubusercontent.com/14007745/176798128-8bd25a40-9f07-46fa-b9e6-60ab464aaa8d.gif)

## Notes

- I believe it will also help us in the voting process, since an error or reload in this part would cause in the voting to start over. 
- My intent is that indexedDb and context are always up to date, except when the configuration is being changed.

## Board issue

- Closes #35 
