### PR TITLE
feat: get election data from notion

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@emotion/styled": "^11.9.3",
     "@notionhq/client": "^1.0.4",
     "dexie": "^3.2.2",
+    "dexie-react-hooks": "^1.1.1",
     "framer-motion": "^6.3.10",
     "next": "12.1.6",
     "react": "18.1.0",

--- a/packages/entities/notion.ts
+++ b/packages/entities/notion.ts
@@ -4,7 +4,7 @@ export interface GetAvaiableElectionsResponse {
   message: string;
 }
 
-interface AvaiableElections {
+export interface AvaiableElections {
   electionId: string;
   electionName: string;
 }

--- a/packages/entities/notion.ts
+++ b/packages/entities/notion.ts
@@ -7,6 +7,7 @@ export interface GetAvaiableElectionsResponse {
 export interface AvaiableElections {
   electionId: string;
   electionName: string;
+  position: string;
 }
 
 export interface GetElectionPageResponse {

--- a/packages/features/config-context.tsx
+++ b/packages/features/config-context.tsx
@@ -1,9 +1,10 @@
+import { useLiveQuery } from 'dexie-react-hooks';
 import { useCallback, useEffect, useState } from 'react';
 
 import { ChildrenProps, ReactEvent } from '@packages/utils/react';
 import createCtx from '@packages/utils/createCtx';
 import { FormState } from '@packages/entities/config-modal';
-import { getConfiguration } from '@packages/repository/indexedDb';
+import { db, getConfiguration } from '@packages/repository/indexedDb';
 
 const defaultInitialState = {
   electionDatabaseId: '',
@@ -35,6 +36,18 @@ function ConfigProvider({ children }: ChildrenProps) {
 
     loadInitialState();
   }, []);
+
+  const configuration = useLiveQuery(
+    async () =>
+      await db.configuration.bulkGet([
+        'electionDatabaseId',
+        'resultsDatabaseId',
+      ]),
+  );
+
+  useEffect(() => {
+    console.log(configuration);
+  }, [configuration]);
 
   const [formState, setFormState] = useState<FormState>(defaultInitialState);
 

--- a/packages/hooks/api.ts
+++ b/packages/hooks/api.ts
@@ -1,10 +1,10 @@
-import { AvaiableElections } from '@packages/entities/notion';
+import { GetAvaiableElectionsResponse } from '@packages/entities/notion';
 
 const MEMBERS_URL = (databaseId: string) =>
   `/api/elections?databaseId=${databaseId}`;
 export const electionsApi = {
   get: async (databaseId: string) =>
-    fetchData<AvaiableElections[]>(MEMBERS_URL(databaseId), {
+    fetchData<GetAvaiableElectionsResponse>(MEMBERS_URL(databaseId), {
       method: 'GET',
     }),
 };

--- a/packages/hooks/api.ts
+++ b/packages/hooks/api.ts
@@ -1,10 +1,10 @@
 import { GetAvaiableElectionsResponse } from '@packages/entities/notion';
 
-const MEMBERS_URL = (databaseId: string) =>
+const ELECTIONS_URL = (databaseId: string) =>
   `/api/elections?databaseId=${databaseId}`;
 export const electionsApi = {
   get: async (databaseId: string) =>
-    fetchData<GetAvaiableElectionsResponse>(MEMBERS_URL(databaseId), {
+    fetchData<GetAvaiableElectionsResponse>(ELECTIONS_URL(databaseId), {
       method: 'GET',
     }),
 };

--- a/packages/hooks/api.ts
+++ b/packages/hooks/api.ts
@@ -12,7 +12,7 @@ export const electionsApi = {
 async function fetchData<T>(
   input: RequestInfo,
   init?: RequestInit | undefined,
-): Promise<T> {
+): Promise<T | undefined> {
   const res = await fetch(input, {
     ...init,
     headers: {
@@ -22,7 +22,10 @@ async function fetchData<T>(
   });
 
   // validate response
-  if (!res.ok) throw Error(`${res.status}: ${res.statusText}`);
+  if (!res.ok) {
+    console.warn(`${res.status}: ${res.statusText}`);
+    return;
+  }
 
   return await res.json();
 }

--- a/packages/hooks/api.ts
+++ b/packages/hooks/api.ts
@@ -1,0 +1,28 @@
+import { AvaiableElections } from '@packages/entities/notion';
+
+const MEMBERS_URL = (databaseId: string) =>
+  `/api/elections?databaseId=${databaseId}`;
+export const electionsApi = {
+  get: async (databaseId: string) =>
+    fetchData<AvaiableElections[]>(MEMBERS_URL(databaseId), {
+      method: 'GET',
+    }),
+};
+
+async function fetchData<T>(
+  input: RequestInfo,
+  init?: RequestInit | undefined,
+): Promise<T> {
+  const res = await fetch(input, {
+    ...init,
+    headers: {
+      ...(init?.headers ?? {}),
+      'Content-type': 'application/json',
+    },
+  });
+
+  // validate response
+  if (!res.ok) throw Error(`${res.status}: ${res.statusText}`);
+
+  return await res.json();
+}

--- a/packages/repository/indexedDb.ts
+++ b/packages/repository/indexedDb.ts
@@ -21,7 +21,7 @@ export default class VSDatabase extends Dexie {
   }
 }
 
-const db = new VSDatabase();
+export const db = new VSDatabase();
 
 export async function getConfiguration(): Promise<ConfigStates> {
   const getResult = await db.configuration.bulkGet([

--- a/packages/utils/react.tsx
+++ b/packages/utils/react.tsx
@@ -1,6 +1,7 @@
 import { EffectCallback, FC, ReactNode, useEffect, ChangeEvent } from 'react';
 
 export type ReactEvent = ChangeEvent<HTMLInputElement>;
+export type ReactSelectEvent = ChangeEvent<HTMLSelectElement>;
 
 export interface ChildrenProps {
   readonly children: ReactNode;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useState } from 'react';
-import { Heading, Box, Flex, Select, Button } from '@chakra-ui/react';
+import {
+  Heading,
+  Box,
+  Flex,
+  Select,
+  Button,
+  Alert,
+  AlertIcon,
+} from '@chakra-ui/react';
 import Head from 'next/head';
 
 import NavBar from '@packages/components/NavBar';
@@ -21,7 +29,7 @@ const Home: NextPage = () => {
     async function fetchData() {
       if (electionDatabaseId) {
         const result = await electionsApi.get(electionDatabaseId);
-        setAvaiableElections(result.results || []);
+        setAvaiableElections(result?.results || []);
       }
     }
 
@@ -76,6 +84,12 @@ const Home: NextPage = () => {
                 Iniciar Votação
               </Button>
             </Box>
+            {!avaiableElections.length && (
+              <Alert status="warning" bottom="0">
+                <AlertIcon />
+                Nenhuma eleição encontrada, verifique suas chaves do notion!
+              </Alert>
+            )}
           </main>
         </Box>
       </Flex>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,10 @@
+import { useEffect } from 'react';
 import { Heading, Box, Flex, Select, Button } from '@chakra-ui/react';
 import Head from 'next/head';
 
 import NavBar from '@packages/components/NavBar';
+import { electionsApi } from '@packages/hooks/api';
+import { useConfigStates } from '@packages/features/config-context';
 
 import type { NextPage } from 'next';
 
@@ -19,6 +22,19 @@ const mockElections = [
 ];
 
 const Home: NextPage = () => {
+  const { electionDatabaseId } = useConfigStates();
+
+  useEffect(() => {
+    async function fetchData() {
+      if (electionDatabaseId) {
+        const result = await electionsApi.get(electionDatabaseId);
+        console.log(result);
+      }
+    }
+
+    fetchData();
+  }, [electionDatabaseId]);
+
   return (
     <>
       <NavBar />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,39 +1,44 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Heading, Box, Flex, Select, Button } from '@chakra-ui/react';
 import Head from 'next/head';
 
 import NavBar from '@packages/components/NavBar';
 import { electionsApi } from '@packages/hooks/api';
+import { AvaiableElections } from '@packages/entities/notion';
 import { useConfigStates } from '@packages/features/config-context';
+import { ReactSelectEvent } from '@packages/utils/react';
 
 import type { NextPage } from 'next';
 
-const mockElections = [
-  {
-    electionId: '47b8e344-0243-435d-822b-4192f691f5a7',
-    electionName: 'Dimensão colégio - 06',
-    keyPosition: 'Chefe de turma',
-  },
-  {
-    electionId: '58ebc9cd-5a4d-4902-876c-95008a537657',
-    electionName: 'Dimensão colégio - 07',
-    keyPosition: 'Chefe de turma',
-  },
-];
-
 const Home: NextPage = () => {
   const { electionDatabaseId } = useConfigStates();
+  const [selectedElectionId, setSelectedElectionId] = useState<string>('');
+  const [avaiableElections, setAvaiableElections] = useState<
+    AvaiableElections[]
+  >([]);
 
   useEffect(() => {
     async function fetchData() {
       if (electionDatabaseId) {
         const result = await electionsApi.get(electionDatabaseId);
-        console.log(result);
+        setAvaiableElections(result.results || []);
       }
     }
 
     fetchData();
   }, [electionDatabaseId]);
+
+  const handleSelectChage = (event: ReactSelectEvent) => {
+    setSelectedElectionId(event?.target?.value);
+  };
+
+  const onSubmit = () => {
+    console.log(selectedElection);
+  };
+
+  const [selectedElection] = avaiableElections?.filter(
+    (election) => election.electionId === selectedElectionId,
+  );
 
   return (
     <>
@@ -55,14 +60,19 @@ const Home: NextPage = () => {
               width="100%"
               py="30px"
             >
-              <Select>
-                {mockElections.map((voting) => (
-                  <option key={voting.electionName}>
-                    {voting.electionName}
-                  </option>
-                ))}
+              <Select
+                placeholder="Selecione uma eleição"
+                onChange={handleSelectChage}
+              >
+                {avaiableElections &&
+                  avaiableElections.map((voting) => (
+                    <option key={voting.electionId} value={voting.electionId}>
+                      {voting.electionName} - {voting.position}
+                    </option>
+                  ))}
               </Select>
-              <Button colorScheme="blue" marginLeft="10px">
+
+              <Button colorScheme="blue" marginLeft="10px" onClick={onSubmit}>
                 Iniciar Votação
               </Button>
             </Box>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1445,6 +1445,11 @@ detect-node-es@^1.1.0:
   resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
   integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
 
+dexie-react-hooks@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/dexie-react-hooks/-/dexie-react-hooks-1.1.1.tgz#ff405cc89e5d899ddbac5e40d593f83f9a74106a"
+  integrity sha512-Cam5JP6PxHN564RvWEoe8cqLhosW0O4CAZ9XEVYeGHJBa6KEJlOpd9CUpV3kmU9dm2MrW97/lk7qkf1xpij7gA==
+
 dexie@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/dexie/-/dexie-3.2.2.tgz#fa6f2a3c0d6ed0766f8d97a03720056f88fe0e01"


### PR DESCRIPTION
# Description

This PR adds the comunication with our nextApi and client. It uses the get avaiable elections endpoint to serve as data for our Select in the index page.


## Changes

- Created api hook with get elections route mapped.
- Loaded the obtained value as select options.
- Enhance Select form functionality

## Notes

- Maybe hooks is not a good folder name for this, I think I will move the api call's for the repository folder as notion.ts

## Board issue

- Closes #44 
