### PR TITLE
Feat/create input panel

### DIFF
--- a/packages/components/BaseButton.tsx
+++ b/packages/components/BaseButton.tsx
@@ -10,27 +10,27 @@ interface Props {
 
 const VARIANT_MAP: Record<
   Variant,
-  { padding: number; color: string; fontColor: string }
+  { paddingY: number; color: string; fontColor: string }
 > = {
-  confirm: { padding: 6, color: '#46F70C', fontColor: 'white' },
-  correct: { padding: 4, color: '#FFD600', fontColor: 'white' },
-  blank: { padding: 4, color: '#ffffff', fontColor: 'black' },
-  number: { padding: 4, color: '#000000', fontColor: 'white' },
+  confirm: { paddingY: 8, color: '#46F70C', fontColor: 'white' },
+  correct: { paddingY: 5, color: '#FFD600', fontColor: 'white' },
+  blank: { paddingY: 5, color: '#ffffff', fontColor: 'black' },
+  number: { paddingY: 6, color: '#000000', fontColor: 'white' },
 };
 
-export function BaseButton(props: Props) {
+export default function BaseButton(props: Props) {
   const { text, onClick, variant } = props;
-  const { color, padding, fontColor } = VARIANT_MAP[variant];
+  const { color, paddingY: paddingY, fontColor } = VARIANT_MAP[variant];
   return (
     <Button
-      marginLeft={20}
       onClick={onClick}
       bg={color}
-      padding={padding}
+      py={paddingY}
       border="1px"
       style={{ color: fontColor }}
       fontWeight="bold"
       boxShadow="md"
+      w="100%"
     >
       {text}
     </Button>

--- a/packages/components/InputPanel.tsx
+++ b/packages/components/InputPanel.tsx
@@ -1,0 +1,60 @@
+import { Flex, Grid, GridItem } from '@chakra-ui/react';
+
+import BaseButton from './BaseButton';
+
+const generateNumberList = (max = 10) => {
+  return Array(max)
+    .fill(null)
+    .map((_, i) => (i + 1) % max);
+};
+
+const numericButtons = generateNumberList().map((btnText) => {
+  return (
+    <GridItem
+      key={btnText}
+      w="100%"
+      h="100%"
+      colStart={btnText === 0 ? 2 : undefined}
+    >
+      <BaseButton
+        onClick={() => {}}
+        text={btnText.toString()}
+        variant="number"
+      />
+    </GridItem>
+  );
+});
+
+export default function InputPanel() {
+  return (
+    <Flex
+      h="100%"
+      direction="column"
+      alignItems="center"
+      justifyContent="center"
+      px="2"
+      backgroundColor="blackAlpha.700"
+    >
+      <Grid
+        templateColumns="repeat(3, 1fr)"
+        h="30%"
+        w="50%"
+        gap="1"
+        justifyItems="center"
+        alignContent="center"
+      >
+        {numericButtons}
+      </Grid>
+      <Flex
+        w="80%"
+        alignItems="flex-end"
+        justifyContent="space-between"
+        gap="6"
+      >
+        <BaseButton onClick={() => {}} text="Branco" variant="blank" />
+        <BaseButton onClick={() => {}} text="Corrige" variant="correct" />
+        <BaseButton onClick={() => {}} text="Confirma" variant="confirm" />
+      </Flex>
+    </Flex>
+  );
+}

--- a/pages/voting.tsx
+++ b/pages/voting.tsx
@@ -1,6 +1,7 @@
-import { Box, Grid } from '@chakra-ui/react';
+import { Grid } from '@chakra-ui/react';
 
 import Display from '@packages/components/Display';
+import InputPanel from '@packages/components/InputPanel';
 
 import type { NextPage } from 'next';
 
@@ -8,7 +9,7 @@ const VotingPage: NextPage = () => {
   return (
     <Grid templateColumns="2fr 1fr" gap="3" h="100vh" p="10">
       <Display />
-      <Box bg="blue" h="100%" boxShadow="dark-lg" />
+      <InputPanel />
     </Grid>
   );
 };


### PR DESCRIPTION
# Description

 - Create the basic input panel layout with numeric and actions buttons, also apply some changes to the `Base
 Button` component.

Follows a print of the `voting` page current state

![image](https://user-images.githubusercontent.com/57193296/178265300-23a6e900-fae9-4036-acd6-2063e18b91df.png)


## Changes
- Change the `padding` property of the `BaseButton` component to be `paddingY`  which controls just the vertical padding
- Set the `BaseButton` width to be fully controlled by its parent element.

## Board issue

- Closes #20  
